### PR TITLE
First working iteration of web tool

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -12,12 +12,13 @@ https://docs.djangoproject.com/en/3.1/ref/settings/
 
 from pathlib import Path
 from environs import Env
+import os
 
 env = Env()
 env.read_env()
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
-BASE_DIR = Path(__file__).resolve().parent.parent
+BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
 
 # Quick-start development settings - unsuitable for production
@@ -63,7 +64,7 @@ ROOT_URLCONF = 'config.urls'
 TEMPLATES = [
     {
         'BACKEND': 'django.template.backends.django.DjangoTemplates',
-        'DIRS': [str(BASE_DIR.joinpath('templates'))],
+        'DIRS': [os.path.join(BASE_DIR, 'templates')],
         'APP_DIRS': True,
         'OPTIONS': {
             'context_processors': [
@@ -83,10 +84,7 @@ WSGI_APPLICATION = 'config.wsgi.application'
 # https://docs.djangoproject.com/en/3.1/ref/settings/#databases
 
 DATABASES = {
-    'default': {
-        'ENGINE': 'django.db.backends.sqlite3',
-        'NAME': BASE_DIR / 'db.sqlite3',
-    }
+    'default': env.dj_db_url("DATABASE_URL")
 }
 
 
@@ -127,8 +125,10 @@ USE_TZ = True
 # https://docs.djangoproject.com/en/3.1/howto/static-files/
 
 STATIC_URL = '/static/'
-STATICFILES_DIRS = [str(BASE_DIR.joinpath('static'))]
-STATIC_ROOT = str(BASE_DIR.joinpath('staticfiles'))
+# STATICFILES_DIRS = ( 
+#    os.path.normpath(os.path.join(BASE_DIR, 'static')), 
+# )
+STATIC_ROOT = os.path.join(BASE_DIR, 'staticfiles')
 STATICFILES_STORAGE = 'whitenoise.storage.CompressedManifestStaticFilesStorage'
 
 CRISPY_TEMPLATE_PACK = 'bootstrap4'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,9 @@
+dj-database-url
+django
+django-crispy-forms
+environs
+gunicorn
+pandas
+psycopg2
+requests
+whitenoise


### PR DESCRIPTION
A test version of this tool can be found at [https://test-bedmaker2.herokuapp.com/](https://test-bedmaker2.herokuapp.com/)

Miscellaneous changes:
- Added vscode files to .gitignore file
- Updated Admin page

Website styling:
- Added html templates for base, home, import, and view
- Setup base template with navbar
- Added datatables to display imported data

Database:
- Added models for BedfileRequest, Gene, and Transcript to database

Getting Data:
- Web form to upload ensembl gene IDs and Bedfile Request meta data
- Get gene details from Ensembl API
- Get RefSeq stable ID/MANE details from TARK API

Deployment:
- Configured for Heroku deployment

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moka-guys/bedfile_editor/2)
<!-- Reviewable:end -->
